### PR TITLE
Add alliance color indicator

### DIFF
--- a/src/main/java/org/sert2521/powerup/util/Camera.kt
+++ b/src/main/java/org/sert2521/powerup/util/Camera.kt
@@ -43,7 +43,7 @@ object Camera {
                         else -> "Teleoperated"
                     }
 
-                    val allianceColor = when(DriverStation.getInstance().alliance){
+                    val allianceColor = when(DriverStation.getInstance().alliance) {
                         DriverStation.Alliance.Red -> Scalar(0.0, 0.0, 255.0)
                         DriverStation.Alliance.Blue -> Scalar(255.0, 0.0, 0.0)
                         else -> Scalar(255.0, 255.0, 255.0)
@@ -53,8 +53,8 @@ object Camera {
                     Imgproc.putText(source, text, Point(0.0, 0.0), FONT_HERSHEY_SIMPLEX, 10.0, Scalar(0.0, 255.0, 0.0), 2)
                     Imgproc.rectangle(source, Point(5.0, 5.0), Point(165.0, 60.0), allianceColor, -1)
                     Imgproc.putText(source, "${DriverStation.getInstance().alliance}", Point(5.0, 53.0), FONT_HERSHEY_COMPLEX, 1.85, Scalar(255.0, 255.0, 255.0), 2, 16, false)
-                    out.write(source)
 
+                    out.write(source)
                     outputStream.putFrame(source)
                 }
             }

--- a/src/main/java/org/sert2521/powerup/util/Camera.kt
+++ b/src/main/java/org/sert2521/powerup/util/Camera.kt
@@ -52,7 +52,17 @@ object Camera {
                     val text = "Time: ${DriverStation.getInstance().matchTime}\nMode: $gameMode"
                     Imgproc.putText(source, text, Point(0.0, 0.0), FONT_HERSHEY_SIMPLEX, 10.0, Scalar(0.0, 255.0, 0.0), 2)
                     Imgproc.rectangle(source, Point(5.0, 5.0), Point(165.0, 60.0), allianceColor, -1)
-                    Imgproc.putText(source, "${DriverStation.getInstance().alliance}", Point(5.0, 53.0), FONT_HERSHEY_COMPLEX, 1.85, Scalar(255.0, 255.0, 255.0), 2, 16, false)
+                    Imgproc.putText(
+                            source,
+                            DriverStation.getInstance().alliance.toString(),
+                            Point(5.0, 53.0),
+                            FONT_HERSHEY_COMPLEX,
+                            1.85,
+                            Scalar(255.0, 255.0, 255.0),
+                            2,
+                            16,
+                            false
+                    )
 
                     out.write(source)
                     outputStream.putFrame(source)

--- a/src/main/java/org/sert2521/powerup/util/Camera.kt
+++ b/src/main/java/org/sert2521/powerup/util/Camera.kt
@@ -2,6 +2,7 @@ package org.sert2521.powerup.util
 
 import edu.wpi.first.wpilibj.CameraServer
 import edu.wpi.first.wpilibj.DriverStation
+import org.opencv.core.Core.FONT_HERSHEY_COMPLEX
 import org.opencv.core.Core.FONT_HERSHEY_SIMPLEX
 import org.opencv.core.Mat
 import org.opencv.core.Point
@@ -42,9 +43,16 @@ object Camera {
                         else -> "Teleoperated"
                     }
 
+                    val allianceColor = when(DriverStation.getInstance().alliance){
+                        DriverStation.Alliance.Red -> Scalar(0.0, 0.0, 255.0)
+                        DriverStation.Alliance.Blue -> Scalar(255.0, 0.0, 0.0)
+                        else -> Scalar(255.0, 255.0, 255.0)
+                    }
+
                     val text = "Time: ${DriverStation.getInstance().matchTime}\nMode: $gameMode"
                     Imgproc.putText(source, text, Point(0.0, 0.0), FONT_HERSHEY_SIMPLEX, 10.0, Scalar(0.0, 255.0, 0.0), 2)
-
+                    Imgproc.rectangle(source, Point(5.0, 5.0), Point(165.0, 60.0), allianceColor, -1)
+                    Imgproc.putText(source, "${DriverStation.getInstance().alliance}", Point(5.0, 53.0), FONT_HERSHEY_COMPLEX, 1.85, Scalar(255.0, 255.0, 255.0), 2, 16, false)
                     out.write(source)
 
                     outputStream.putFrame(source)

--- a/src/main/java/org/sert2521/powerup/util/Camera.kt
+++ b/src/main/java/org/sert2521/powerup/util/Camera.kt
@@ -56,12 +56,8 @@ object Camera {
                             source,
                             DriverStation.getInstance().alliance.toString(),
                             Point(5.0, 53.0),
-                            FONT_HERSHEY_COMPLEX,
-                            1.85,
-                            Scalar(255.0, 255.0, 255.0),
-                            2,
-                            16,
-                            false
+                            FONT_HERSHEY_COMPLEX, 1.85, Scalar(255.0, 255.0, 255.0),
+                            2, 16, false
                     )
 
                     out.write(source)

--- a/src/main/java/org/sert2521/powerup/util/Camera.kt
+++ b/src/main/java/org/sert2521/powerup/util/Camera.kt
@@ -43,7 +43,7 @@ object Camera {
                         else -> "Teleoperated"
                     }
 
-                    val allianceColor = when(DriverStation.getInstance().alliance) {
+                    val allianceColor = when (DriverStation.getInstance().alliance) {
                         DriverStation.Alliance.Red -> Scalar(0.0, 0.0, 255.0)
                         DriverStation.Alliance.Blue -> Scalar(255.0, 0.0, 0.0)
                         else -> Scalar(255.0, 255.0, 255.0)


### PR DESCRIPTION
Creates a rectangle at the upper left-hand corner of the video that matches the color of the robot's alliance.